### PR TITLE
Specified django-haystack <2.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ install_requires = [
     'Django>=1.3',
     'django-cms>=2.1.3',
     'django-classy-tags>=0.3.2',
-    'django-haystack>=1.2.4',
+    'django-haystack>=1.2.4,<2.0.0',
 ]
 
 setup(


### PR DESCRIPTION
[Docs](http://django-cms-search.readthedocs.org/en/latest/#requirements) indicate lack of compatibility with django-haystack before 2.0.
