### PR TITLE
django.conf.urls.defaults is deprecated, using django.conf.urls instead

### DIFF
--- a/cms_search/cms_app.py
+++ b/cms_search/cms_app.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 from django.utils.translation import ugettext_lazy as _
 
 from cms.app_base import CMSApp


### PR DESCRIPTION
Since django 1.5, using the plugin is yielding a DeprecationWarning when running server.

``` python
DeprecationWarning: django.conf.urls.defaults is deprecated; use django.conf.urls instead
```

I just removed ".defaults" from the import.
